### PR TITLE
AP20-268: allow createWriteStream to accept S3 ManagedUpload options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ utils.createReadStream(TEST_DATA_SRC)
 	}));
 ```
 
+### Upload options (`partSize` / `queueSize`)
+
+`createWriteStream(destination, cb, throwError, uploadOptions)` accepts an
+optional 4th argument that is forwarded verbatim to the S3
+[ManagedUpload](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property).
+It is fully backward compatible — when omitted, the previous SDK defaults
+(`partSize` 5 MB, `queueSize` 4) apply. Use it to bound peak memory when
+uploading many large objects concurrently:
+
+```js
+// Cap the in-flight multipart buffer per upload (~partSize * queueSize).
+utils.createWriteStream(destination, cb, false, { partSize: 5 * 1024 * 1024, queueSize: 2 });
+```
+
+`createWriteArrayStream()` accepts the same optional `uploadOptions` argument.
+
 ## createArrayWriteStream()
 writes json array to S3.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apination-stream-utils",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apination-stream-utils",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha tests/integration/",
+    "test:unit": "mocha tests/unit/",
     "doc": "mocha -R markdown tests/integration/",
     "release-patch": "npm version patch && git push --all && git push --tags",
     "release-minor": "npm version minor && git push --all && git push --tags"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apination-stream-utils",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Stream reading, parsing and writing utils",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,12 @@ exports.createReadArrayStream = function createReadArrayStream(source) {
  *
  * @param	{{bucketName: string, keyPrefix: string}|string}	destination	Where the data should be uploaded to
  * @param 	{Function}	cb	Callback to execute when the upload if complete
+ * @param	{boolean}	[throwError=false]	Re-throw upload errors instead of swallowing them
+ * @param	{object}	[uploadOptions={}]	Options forwarded to S3 ManagedUpload (e.g. { partSize, queueSize }).
+ *						Defaults to an empty object, which preserves the previous SDK defaults.
  * @return	{object}	Writable stream
  */
-exports.createWriteStream = function createWriteStream(destination, cb, throwError = false) {
+exports.createWriteStream = function createWriteStream(destination, cb, throwError = false, uploadOptions = {}) {
 	if (!destination) throw new TypeError('destination argument required');
 	if (typeof destination === 'string') {
 		const m = destination.match(RX_S3);
@@ -85,6 +88,7 @@ exports.createWriteStream = function createWriteStream(destination, cb, throwErr
 		throw new TypeError('destination must be either a String in format "s3://bucketName/keyPrefix" or an Object {bucketName: string, keyPrefix: string}');
 	}
 	if (cb && typeof cb !== 'function') throw new TypeError('cb argument, when provided, must be a Function');
+	if (uploadOptions === null || typeof uploadOptions !== 'object') throw new TypeError('uploadOptions argument, when provided, must be an Object');
 
 	const passThroughStream = new PassThrough();
 	if (cb) passThroughStream.on('error', cb);
@@ -104,7 +108,7 @@ exports.createWriteStream = function createWriteStream(destination, cb, throwErr
 
 	// console.log(passThroughStream)
 
-	s3.upload(params, function (err, data) {
+	s3.upload(params, uploadOptions, function (err, data) {
 		passThroughStream.writing = false
 		if (err) {
 			debug(`${uploadingTo} upload failed`);
@@ -128,11 +132,13 @@ exports.createWriteStream = function createWriteStream(destination, cb, throwErr
  * Creates an object write stream for a given url
  * @param	{string}	url	Where the data should be uploaded to
  * @param 	{Function}	cb	Callback to execute when the upload if complete
+ * @param	{boolean}	[throwError=false]	Re-throw upload errors instead of swallowing them
+ * @param	{object}	[uploadOptions={}]	Options forwarded to S3 ManagedUpload (e.g. { partSize, queueSize })
  * @return	{object}	Writable object stream
  */
-exports.createWriteArrayStream = function createWriteArrayStream(url, cb, throwError = false) {
+exports.createWriteArrayStream = function createWriteArrayStream(url, cb, throwError = false, uploadOptions = {}) {
 	const stringify = JSONStream.stringify();
-	const writeStream = exports.createWriteStream(url, cb, throwError)
+	const writeStream = exports.createWriteStream(url, cb, throwError, uploadOptions)
 	stringify.pipe(writeStream);
 
 	Object.defineProperty(

--- a/tests/unit/createWriteStream.options.test.js
+++ b/tests/unit/createWriteStream.options.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const aws = require('aws-sdk');
+const expect = require('chai').expect;
+
+// Stub aws.S3 so the upload path runs entirely offline — no credentials, no
+// network. The real ManagedUpload is exercised by the integration suite; here
+// we only assert how createWriteStream forwards arguments to s3.upload().
+const originalS3 = aws.S3;
+let lastUpload;
+
+function installS3Stub() {
+	lastUpload = null;
+	aws.S3 = function S3Stub() {
+		return {
+			upload(params, options, cb) {
+				// Mirror the real SDK overload: upload(params, cb) or upload(params, options, cb).
+				if (typeof options === 'function') {
+					cb = options;
+					options = undefined;
+				}
+				lastUpload = { params, options };
+				setImmediate(() => cb(null, { Bucket: params.Bucket, Key: params.Key }));
+				return { on() {} };
+			}
+		};
+	};
+}
+
+function restoreS3() {
+	aws.S3 = originalS3;
+}
+
+const utils = require('../../src');
+
+describe('createWriteStream() uploadOptions', () => {
+
+	const destination = { bucketName: 'test-bucket', keyPrefix: 'unit/test-' };
+
+	beforeEach(installS3Stub);
+	afterEach(restoreS3);
+
+	it('forwards uploadOptions to s3.upload as the options argument', done => {
+		const uploadOptions = { partSize: 5 * 1024 * 1024, queueSize: 2 };
+		const stream = utils.createWriteStream(destination, () => {
+			expect(lastUpload.options).to.deep.equal(uploadOptions);
+			done();
+		}, false, uploadOptions);
+		stream.end('payload');
+	});
+
+	it('passes an empty options object when uploadOptions is omitted (backward compatible)', done => {
+		const stream = utils.createWriteStream(destination, () => {
+			expect(lastUpload.options).to.deep.equal({});
+			done();
+		});
+		stream.end('payload');
+	});
+
+	it('throws TypeError when uploadOptions is not an object', () => {
+		expect(() => utils.createWriteStream(destination, () => {}, false, 'nope')).to.throw(TypeError);
+		expect(() => utils.createWriteStream(destination, () => {}, false, null)).to.throw(TypeError);
+	});
+
+	it('createWriteArrayStream forwards uploadOptions too', done => {
+		const uploadOptions = { queueSize: 1 };
+		const stream = utils.createWriteArrayStream(destination, () => {
+			expect(lastUpload.options).to.deep.equal(uploadOptions);
+			done();
+		}, false, uploadOptions);
+		stream.end();
+	});
+});


### PR DESCRIPTION
## Do reviewers need to merge this PR after the review

YES. Version is bumped to **0.6.0** in this PR. After merge, please push the matching tag `v0.6.0` (e.g. `git tag v0.6.0 && git push --tags`, or your release flow) so the follow-up `cn-docusign` PR can pin to it.

## Jira issue link

[AP20-268](https://projectcx.atlassian.net/browse/AP20-268)

## Type of change

- [x] Feature — new functionality

## Description

Add an optional 4th `uploadOptions` argument to `createWriteStream` (and `createWriteArrayStream`) that is forwarded verbatim to S3 `ManagedUpload` (`s3.upload(params, uploadOptions, cb)`).

Motivation: `cn-docusign`'s `get_detailed_rooms_v2` Lambda OOMs at 256 MB when downloading several large (~30 MB) documents concurrently. CloudWatch memory traces show the growth is entirely in native `Buffer` memory (`external`/`arrayBuffers`), driven by the S3 multipart upload window (`partSize × queueSize`) multiplied by the download concurrency. Today there is no way to tune that window because the options object is never passed to `s3.upload`. This change lets callers cap it (e.g. `{ partSize: 5MB, queueSize: 2 }`).

Backward compatible: when `uploadOptions` is omitted it defaults to `{}`, which is equivalent to the previous `s3.upload(params, cb)` call and preserves the SDK defaults (`partSize` 5 MB, `queueSize` 4).

Version bumped 0.5.0 → 0.6.0 (`package.json` + `package-lock.json`).

## How to test

```
npm install
npm run test:unit
```

The new offline suite (`tests/unit/createWriteStream.options.test.js`) stubs `aws.S3`, so it needs no credentials or network. It covers:
1. `uploadOptions` is forwarded to `s3.upload` as the options argument
2. omitting it passes `{}` (backward compatible)
3. a non-object `uploadOptions` throws `TypeError`
4. `createWriteArrayStream` forwards it too

## Self-Review Checklist

### Preparation

- [x] Branch is named after the Jira ticket (`AP20-268-...`)
- [x] PR description is complete — no `TODO` placeholders left
- [x] Code has been self-reviewed as if seeing it for the first time

### Code Quality

- [x] No commented-out code added
- [x] PR scope is coherent — single, indivisible change to the write-stream API

### Testing

- [x] Unit tests cover the changes (4 passing, offline)
- [S] Integration tests unchanged — existing suite requires live S3 credentials; behavior is unchanged when `uploadOptions` is omitted

### Dependencies & Configuration

- [x] No new dependencies added
- [x] Lock file committed (`package-lock.json` version bump only)
- [S] `npm audit` — pre-existing advisories on the default branch, not introduced here
- [x] No environment variables added or changed

### Deployment
- [S] Tested on staging — library only; exercised via the `cn-docusign` follow-up PR
- [S] Tested on production — same as above

[AP20-268]: https://projectcx.atlassian.net/browse/AP20-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ