### PR TITLE
AP20-813: add getObjectSize to size an object without downloading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ package.json (installed automatically with `npm i`)
 
 -	[JSONStream](https://www.npmjs.com/package/JSONStream)
 -	[debug](https://www.npmjs.com/package/debug)
+-	peer — supplied by the consumer, required by the entry point at load time
+	-	[aws-sdk](https://www.npmjs.com/package/aws-sdk) v2. Declared as a peer rather
+		than a dependency because the Lambda runtime already provides it, and
+		shipping it would add the whole SDK to every consumer bundle.
 -	development
 	-	[aws-sdk](https://www.npmjs.com/package/aws-sdk)
 	-	[mocha](https://www.npmjs.com/package/mocha)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ stream.on('end', () => {
 });
 ```
 
+## getObjectSize()
+returns the size of an object in bytes without downloading it. Accepts the same
+locations as `createReadStream()` — `s3://`, `https://s3.amazonaws.com/`,
+`file://`, and the `{ $src }` envelope. For S3 this is a `headObject` call, so
+only metadata is transferred.
+
+Use it to decide how to send a file before sending it, for example choosing
+between a single request and a chunked or signed upload flow.
+
+```js
+const size = await utils.getObjectSize(TEST_DATA_SRC);
+
+if (size > 25 * 1024 * 1024) {
+	// too large for one request — use the signed upload flow
+}
+```
+
+Range locations (`?offset=&length=`) are rejected: `createReadStream()` emits only
+that slice, so no single size would describe both the object and the stream.
+
 ## createReadArrayStream()
 loads JSON array from S3.
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ if (size > 25 * 1024 * 1024) {
 }
 ```
 
-Range locations (`?offset=&length=`) are rejected: `createReadStream()` emits only
-that slice, so no single size would describe both the object and the stream.
+It answers for the stream `createReadStream()` would produce. A range location
+(`?offset=&length=`) therefore returns its `length`, with no request made at all.
+Ranges on `file://` locations are rejected, because `createReadStream()` does not
+honour them there either.
 
 ## createReadArrayStream()
 loads JSON array from S3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apination-stream-utils",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apination-stream-utils",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "event-stream": "3.3.3",
     "uuid": "^2.0.2"
   },
+  "peerDependencies": {
+    "aws-sdk": "^2.3.14"
+  },
   "devDependencies": {
     "aws-sdk": "^2.814.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apination-stream-utils",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Stream reading, parsing and writing utils",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,13 @@ exports.createReadStream = function createReadStream(url) {
 		const params = {
 			Bucket: m[1],
 			Key: m[2],
-			Range: offset !== null && length !== null ? `bytes=${offset}-${offset + length}` : undefined
+			// An HTTP byte range is inclusive at both ends, so the last byte of a
+			// `length`-byte slice is at `offset + length - 1`. Asking for
+			// `offset + length` returned one byte too many on every range read. It went
+			// unnoticed because the writers of these ranges separate records with a
+			// newline and JSON.parse ignores trailing whitespace - it would corrupt any
+			// range whose next byte is not whitespace.
+			Range: offset !== null && length !== null ? `bytes=${offset}-${offset + length - 1}` : undefined
 		};
 
 		const s3 = new aws.S3();
@@ -55,6 +61,10 @@ exports.createReadStream = function createReadStream(url) {
  * upstream steps wrap one in - so that anything streamable is also sizeable.
  * For S3 this is a headObject call: metadata only, no body transferred.
  *
+ * Answers for the stream createReadStream would produce, which for a range url is
+ * its `length` and needs no request at all. Ranges on file:// locations are refused,
+ * because createReadStream does not honour them there either.
+ *
  * `async` so that every failure - a bad argument, an unsupported location, a
  * missing local file, an S3 error - reaches the caller as a rejection. A caller
  * writing `getObjectSize(src).then(...).catch(handle)` must not have some of these
@@ -67,18 +77,12 @@ exports.getObjectSize = async function getObjectSize(url) {
 	if (typeof url === 'object' && url && (OBJECT_SOURCE_KEY in url)) url = url[OBJECT_SOURCE_KEY];
 	if (typeof url !== 'string' || !url.length) throw new TypeError('url argument must be a non-empty String');
 
-	// Checked before the branch so it holds for file:// too. RX_FILE is greedy, so a
-	// range suffix would otherwise be swallowed into the path and surface as ENOENT
-	// naming a file that never existed, instead of "ranges are not supported".
-	//
-	// The refusal itself: createReadStream emits only the requested slice, and asks
-	// S3 for `bytes=offset-(offset+length)` - one byte more than length. Neither the
-	// object size nor length describes that stream, so there is nothing honest to
-	// return. (That off-by-one is a bug in createReadStream, tracked separately.)
-	if (RX_RANGE.test(url)) throw new Error('getObjectSize does not support range urls: ' + url);
-
 	if (RX_S3.test(url)) {
 		const m = url.match(RX_S3);
+
+		// A range url describes its own size: createReadStream emits exactly that
+		// many bytes, so answering from the url is both correct and free of a request.
+		if (m[4]) return +m[4];
 
 		debug(`sizing s3://${m[1]}/${m[2]}...`);
 
@@ -96,6 +100,13 @@ exports.getObjectSize = async function getObjectSize(url) {
 		return head.ContentLength;
 	}
 	else if (RX_FILE.test(url)) {
+		// RX_FILE is greedy, so a range suffix ends up inside the path. createReadStream
+		// does not honour ranges for file:// either, so refusing is honest - otherwise
+		// the caller gets ENOENT naming a file that never existed.
+		if (RX_RANGE.test(url)) {
+			throw new Error('getObjectSize does not support range urls for file:// locations: ' + url);
+		}
+
 		const m = url.match(RX_FILE);
 		return fs.statSync(m[1]).size;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,51 @@ exports.createReadStream = function createReadStream(url) {
 };
 
 /**
+ * Returns the size in bytes of an object, without downloading it.
+ *
+ * Accepts every location form createReadStream accepts - an s3:// uri, the
+ * https://s3.amazonaws.com/ equivalent, a file:// path, and the { $src } envelope
+ * upstream steps wrap one in - so that anything streamable is also sizeable.
+ * For S3 this is a headObject call: metadata only, no body transferred.
+ *
+ * @param {string|{$src:string}} url	Remote source location in format s3:// or file://
+ * @return {Promise<number>}	Size of the object in bytes
+ */
+exports.getObjectSize = function getObjectSize(url) {
+	if (typeof url === 'object' && url && (OBJECT_SOURCE_KEY in url)) url = url[OBJECT_SOURCE_KEY];
+	if (typeof url !== 'string' || !url.length) throw new TypeError('url argument must be a non-empty String');
+
+	if (RX_S3.test(url)) {
+		const m = url.match(RX_S3);
+
+		// For a range url createReadStream emits only that slice, and it asks S3 for
+		// `bytes=offset-(offset+length)` - one byte more than length. No single number
+		// describes both the whole object and that stream, so refuse rather than guess.
+		if (m[3]) throw new Error('getObjectSize does not support range urls: ' + url);
+
+		const s3 = new aws.S3();
+
+		return s3.headObject({ Bucket: m[1], Key: m[2] }).promise()
+			.then(head => {
+				// Callers gate "small enough to send in one request" on this number, so
+				// an unknown size must never read as 0.
+				if (head.ContentLength === undefined || head.ContentLength === null) {
+					throw new Error('Object reported no ContentLength: ' + url);
+				}
+
+				return head.ContentLength;
+			});
+	}
+	else if (RX_FILE.test(url)) {
+		const m = url.match(RX_FILE);
+		return Promise.resolve(fs.statSync(m[1]).size);
+	}
+	else {
+		throw new Error('Unexpected url format: ' + url);
+	}
+};
+
+/**
  * Creates an object read stream for a given url
  * @param	{string|any[]}	source	Remote source location in format "s3://..." or Array
  * @return	{object}	Readable object stream

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const uuid = require('uuid');
 
 const RX_S3 = /^(?:s3:\/\/|https:\/\/s3.amazonaws.com\/)([^/]+)\/([^?]+)(?:\?offset=(\d+)&length=(\d+))?$/i;
 const RX_FILE = /^file:\/\/(.+)$/;
+const RX_RANGE = /[?&]offset=\d+&length=\d+$/i;
 const RX_DASHES = /-/g;
 const OBJECT_SOURCE_KEY = '$src';
 
@@ -54,37 +55,49 @@ exports.createReadStream = function createReadStream(url) {
  * upstream steps wrap one in - so that anything streamable is also sizeable.
  * For S3 this is a headObject call: metadata only, no body transferred.
  *
+ * `async` so that every failure - a bad argument, an unsupported location, a
+ * missing local file, an S3 error - reaches the caller as a rejection. A caller
+ * writing `getObjectSize(src).then(...).catch(handle)` must not have some of these
+ * escape past `handle` because they were thrown while evaluating the argument.
+ *
  * @param {string|{$src:string}} url	Remote source location in format s3:// or file://
  * @return {Promise<number>}	Size of the object in bytes
  */
-exports.getObjectSize = function getObjectSize(url) {
+exports.getObjectSize = async function getObjectSize(url) {
 	if (typeof url === 'object' && url && (OBJECT_SOURCE_KEY in url)) url = url[OBJECT_SOURCE_KEY];
 	if (typeof url !== 'string' || !url.length) throw new TypeError('url argument must be a non-empty String');
+
+	// Checked before the branch so it holds for file:// too. RX_FILE is greedy, so a
+	// range suffix would otherwise be swallowed into the path and surface as ENOENT
+	// naming a file that never existed, instead of "ranges are not supported".
+	//
+	// The refusal itself: createReadStream emits only the requested slice, and asks
+	// S3 for `bytes=offset-(offset+length)` - one byte more than length. Neither the
+	// object size nor length describes that stream, so there is nothing honest to
+	// return. (That off-by-one is a bug in createReadStream, tracked separately.)
+	if (RX_RANGE.test(url)) throw new Error('getObjectSize does not support range urls: ' + url);
 
 	if (RX_S3.test(url)) {
 		const m = url.match(RX_S3);
 
-		// For a range url createReadStream emits only that slice, and it asks S3 for
-		// `bytes=offset-(offset+length)` - one byte more than length. No single number
-		// describes both the whole object and that stream, so refuse rather than guess.
-		if (m[3]) throw new Error('getObjectSize does not support range urls: ' + url);
+		debug(`sizing s3://${m[1]}/${m[2]}...`);
 
 		const s3 = new aws.S3();
+		const head = await s3.headObject({ Bucket: m[1], Key: m[2] }).promise();
 
-		return s3.headObject({ Bucket: m[1], Key: m[2] }).promise()
-			.then(head => {
-				// Callers gate "small enough to send in one request" on this number, so
-				// an unknown size must never read as 0.
-				if (head.ContentLength === undefined || head.ContentLength === null) {
-					throw new Error('Object reported no ContentLength: ' + url);
-				}
+		// Callers gate "small enough to send in one request" on this number, so an
+		// unknown size must never read as 0 - while a genuinely empty object must.
+		if (head.ContentLength === undefined || head.ContentLength === null) {
+			throw new Error('Object reported no ContentLength: ' + url);
+		}
 
-				return head.ContentLength;
-			});
+		debug(`s3://${m[1]}/${m[2]} is ${head.ContentLength} bytes`);
+
+		return head.ContentLength;
 	}
 	else if (RX_FILE.test(url)) {
 		const m = url.match(RX_FILE);
-		return Promise.resolve(fs.statSync(m[1]).size);
+		return fs.statSync(m[1]).size;
 	}
 	else {
 		throw new Error('Unexpected url format: ' + url);

--- a/tests/unit/createReadStream.range.test.js
+++ b/tests/unit/createReadStream.range.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const aws = require('aws-sdk');
+const expect = require('chai').expect;
+
+// Stub aws.S3 so the range arithmetic can be asserted offline — the real read path
+// is exercised by the integration suite; here we only care what Range header
+// createReadStream asks S3 for.
+const originalS3 = aws.S3;
+let lastGetObject;
+
+function installS3Stub() {
+	lastGetObject = null;
+	aws.S3 = function S3Stub() {
+		return {
+			getObject(params) {
+				lastGetObject = params;
+				return { createReadStream: () => ({}) };
+			}
+		};
+	};
+}
+
+function restoreS3() {
+	aws.S3 = originalS3;
+}
+
+const utils = require('../../src');
+
+describe('createReadStream() byte ranges', () => {
+
+	beforeEach(installS3Stub);
+	afterEach(restoreS3);
+
+	// An HTTP byte range is inclusive at both ends. `bytes=2706-3038` is 333 bytes,
+	// one more than asked for; the last byte of a 332-byte slice starting at 2706 is
+	// at 3037. Verified against a real workflow payload: at length=332 the slice is
+	// exactly one JSON record, and byte 333 is the newline separating the next one.
+	it('requests exactly `length` bytes, not one more', () => {
+		utils.createReadStream('s3://test-bucket/payload.json?offset=2706&length=332');
+
+		expect(lastGetObject.Range).to.equal('bytes=2706-3037');
+	});
+
+	it('asks for a single byte when length is 1', () => {
+		utils.createReadStream('s3://test-bucket/payload.json?offset=0&length=1');
+
+		expect(lastGetObject.Range).to.equal('bytes=0-0');
+	});
+
+	it('sends no Range header when the url carries no range', () => {
+		utils.createReadStream('s3://test-bucket/payload.json');
+
+		expect(lastGetObject.Range).to.equal(undefined);
+		expect(lastGetObject.Bucket).to.equal('test-bucket');
+		expect(lastGetObject.Key).to.equal('payload.json');
+	});
+});

--- a/tests/unit/getObjectSize.test.js
+++ b/tests/unit/getObjectSize.test.js
@@ -32,6 +32,15 @@ function restoreS3() {
 
 const utils = require('../../src');
 
+// Asserts the rejection channel specifically: a synchronous throw from
+// getObjectSize would fail this helper at the call, before .then is attached.
+function expectRejection(url, pattern) {
+	return utils.getObjectSize(url).then(
+		() => { throw new Error('expected a rejection for ' + JSON.stringify(url)); },
+		err => expect(err.message).to.match(pattern)
+	);
+}
+
 describe('getObjectSize()', () => {
 
 	beforeEach(installS3Stub);
@@ -71,7 +80,13 @@ describe('getObjectSize()', () => {
 	// `bytes=offset-(offset+length)` — one byte more than length. Neither the whole
 	// object size nor length matches the stream, so this must fail loudly.
 	it('rejects a range url instead of returning a size that would not match the stream', () => {
-		expect(() => utils.getObjectSize('s3://test-bucket/file.pdf?offset=0&length=100')).to.throw(/range urls/);
+		return expectRejection('s3://test-bucket/file.pdf?offset=0&length=100', /range urls/);
+	});
+
+	// RX_FILE is greedy, so without a check ahead of the branch the range suffix ends
+	// up inside the path and the caller gets ENOENT for a file that never existed.
+	it('rejects a range url on a file:// path too, not ENOENT for a glued-on suffix', () => {
+		return expectRejection('file:///tmp/probe.bin?offset=0&length=100', /range urls/);
 	});
 
 	// Returning 0 would read as "small" to a caller routing by size, which is the
@@ -79,19 +94,47 @@ describe('getObjectSize()', () => {
 	it('rejects when S3 reports no ContentLength rather than reporting zero', () => {
 		headObjectResult = {};
 
-		return utils.getObjectSize('s3://test-bucket/file.pdf').then(
-			() => { throw new Error('expected rejection'); },
-			err => expect(err.message).to.match(/no ContentLength/)
+		return expectRejection('s3://test-bucket/file.pdf', /no ContentLength/);
+	});
+
+	// The guard is `=== undefined || === null` rather than falsy on purpose. A
+	// "simplification" to `if (!head.ContentLength)` would turn every empty object
+	// into a hard failure, and this is the only test that would catch it.
+	it('returns 0 for an object that is genuinely empty', () => {
+		headObjectResult = { ContentLength: 0 };
+
+		return utils.getObjectSize('s3://test-bucket/empty').then(size => {
+			expect(size).to.equal(0);
+		});
+	});
+
+	it('propagates a headObject failure as a rejection', () => {
+		const failure = new Error('Access Denied');
+		failure.code = 'AccessDenied';
+		aws.S3 = function S3Stub() {
+			return { headObject: () => ({ promise: () => Promise.reject(failure) }) };
+		};
+
+		return expectRejection('s3://test-bucket/file.pdf', /Access Denied/);
+	});
+
+	// Every failure mode is a rejection, not a synchronous throw: a caller writing
+	// `.then(...).catch(handle)` must reach `handle` for all of them.
+	it('rejects rather than throws on a missing file:// path', () => {
+		return expectRejection('file:///definitely/not/here.pdf', /ENOENT/);
+	});
+
+	// Still a TypeError, just delivered through the rejection channel now.
+	it('rejects with TypeError on a missing or non-string url', () => {
+		const assertTypeError = url => utils.getObjectSize(url).then(
+			() => { throw new Error('expected a rejection for ' + JSON.stringify(url)); },
+			err => expect(err).to.be.an.instanceOf(TypeError)
 		);
+
+		return Promise.all([assertTypeError(undefined), assertTypeError(''), assertTypeError(42)]);
 	});
 
-	it('throws TypeError on a missing or non-string url', () => {
-		expect(() => utils.getObjectSize()).to.throw(TypeError);
-		expect(() => utils.getObjectSize('')).to.throw(TypeError);
-		expect(() => utils.getObjectSize(42)).to.throw(TypeError);
-	});
-
-	it('throws on an unsupported url format', () => {
-		expect(() => utils.getObjectSize('https://example.com/file.pdf')).to.throw(/Unexpected url format/);
+	it('rejects on an unsupported url format', () => {
+		return expectRejection('https://example.com/file.pdf', /Unexpected url format/);
 	});
 });

--- a/tests/unit/getObjectSize.test.js
+++ b/tests/unit/getObjectSize.test.js
@@ -76,17 +76,20 @@ describe('getObjectSize()', () => {
 		});
 	});
 
-	// createReadStream emits only the requested slice, and asks S3 for
-	// `bytes=offset-(offset+length)` — one byte more than length. Neither the whole
-	// object size nor length matches the stream, so this must fail loudly.
-	it('rejects a range url instead of returning a size that would not match the stream', () => {
-		return expectRejection('s3://test-bucket/file.pdf?offset=0&length=100', /range urls/);
+	// createReadStream emits exactly `length` bytes for a range url, so the url
+	// already states the size and no request is needed to answer.
+	it('answers a range url from the url itself, without calling S3', () => {
+		return utils.getObjectSize('s3://test-bucket/payload.json?offset=2706&length=332').then(size => {
+			expect(size).to.equal(332);
+			expect(lastHeadObject).to.equal(null);
+		});
 	});
 
-	// RX_FILE is greedy, so without a check ahead of the branch the range suffix ends
-	// up inside the path and the caller gets ENOENT for a file that never existed.
-	it('rejects a range url on a file:// path too, not ENOENT for a glued-on suffix', () => {
-		return expectRejection('file:///tmp/probe.bin?offset=0&length=100', /range urls/);
+	// RX_FILE is greedy, so the range suffix would end up inside the path and the
+	// caller would get ENOENT for a file that never existed. createReadStream does not
+	// honour ranges for file:// either, so refusing is the honest answer.
+	it('rejects a range url on a file:// path, rather than ENOENT for a glued-on suffix', () => {
+		return expectRejection('file:///tmp/probe.bin?offset=0&length=100', /range urls for file:\/\//);
 	});
 
 	// Returning 0 would read as "small" to a caller routing by size, which is the

--- a/tests/unit/getObjectSize.test.js
+++ b/tests/unit/getObjectSize.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const aws = require('aws-sdk');
+const expect = require('chai').expect;
+
+// Stub aws.S3 so the sizing path runs entirely offline — no credentials, no
+// network. Only headObject is needed here, and we record what it was called with
+// so the url parsing can be asserted.
+const originalS3 = aws.S3;
+let lastHeadObject;
+let headObjectResult;
+
+function installS3Stub() {
+	lastHeadObject = null;
+	headObjectResult = { ContentLength: 27061035 };
+	aws.S3 = function S3Stub() {
+		return {
+			headObject(params) {
+				lastHeadObject = params;
+				return { promise: () => Promise.resolve(headObjectResult) };
+			}
+		};
+	};
+}
+
+function restoreS3() {
+	aws.S3 = originalS3;
+}
+
+const utils = require('../../src');
+
+describe('getObjectSize()', () => {
+
+	beforeEach(installS3Stub);
+	afterEach(restoreS3);
+
+	it('returns ContentLength for an s3:// url and does not download the object', () => {
+		return utils.getObjectSize('s3://test-bucket/path/to/file.pdf').then(size => {
+			expect(size).to.equal(27061035);
+			expect(lastHeadObject).to.deep.equal({ Bucket: 'test-bucket', Key: 'path/to/file.pdf' });
+		});
+	});
+
+	it('accepts the https://s3.amazonaws.com/ form, like createReadStream', () => {
+		return utils.getObjectSize('https://s3.amazonaws.com/test-bucket/path/to/file.pdf').then(size => {
+			expect(size).to.equal(27061035);
+			expect(lastHeadObject).to.deep.equal({ Bucket: 'test-bucket', Key: 'path/to/file.pdf' });
+		});
+	});
+
+	it('unwraps the { $src } envelope, like createReadStream', () => {
+		return utils.getObjectSize({ $src: 's3://test-bucket/path/to/file.pdf' }).then(size => {
+			expect(size).to.equal(27061035);
+		});
+	});
+
+	it('sizes a file:// path from the filesystem', () => {
+		const file = path.join(os.tmpdir(), 'stream-utils-getObjectSize.txt');
+		fs.writeFileSync(file, 'twelve bytes');
+
+		return utils.getObjectSize('file://' + file).then(size => {
+			expect(size).to.equal(12);
+			fs.unlinkSync(file);
+		});
+	});
+
+	// createReadStream emits only the requested slice, and asks S3 for
+	// `bytes=offset-(offset+length)` — one byte more than length. Neither the whole
+	// object size nor length matches the stream, so this must fail loudly.
+	it('rejects a range url instead of returning a size that would not match the stream', () => {
+		expect(() => utils.getObjectSize('s3://test-bucket/file.pdf?offset=0&length=100')).to.throw(/range urls/);
+	});
+
+	// Returning 0 would read as "small" to a caller routing by size, which is the
+	// exact mistake this helper exists to prevent.
+	it('rejects when S3 reports no ContentLength rather than reporting zero', () => {
+		headObjectResult = {};
+
+		return utils.getObjectSize('s3://test-bucket/file.pdf').then(
+			() => { throw new Error('expected rejection'); },
+			err => expect(err.message).to.match(/no ContentLength/)
+		);
+	});
+
+	it('throws TypeError on a missing or non-string url', () => {
+		expect(() => utils.getObjectSize()).to.throw(TypeError);
+		expect(() => utils.getObjectSize('')).to.throw(TypeError);
+		expect(() => utils.getObjectSize(42)).to.throw(TypeError);
+	});
+
+	it('throws on an unsupported url format', () => {
+		expect(() => utils.getObjectSize('https://example.com/file.pdf')).to.throw(/Unexpected url format/);
+	});
+});


### PR DESCRIPTION
## What & why

Adds `getObjectSize(url)` — the byte size of an object, without downloading it.

Sizing belongs next to streaming. This package already owns the location grammar (`RX_S3`, `RX_FILE`) and the `{ $src }` unwrapping, so a size helper living anywhere else has to restate both and can only ever cover a subset of the locations `createReadStream` accepts. That is exactly what happened: cn-core grew a local `getS3ObjectSize` with a copy of the URI regex that handled neither `file://` nor range locations, and a reviewer rightly flagged the mismatch. This PR is where that helper should have gone; the cn-core copy is being deleted.

For S3 it is a `headObject` call, so only metadata crosses the wire and a caller can decide *how* to send a file before reading a byte of it.

Motivating case ([AP20-813](https://projectcx.atlassian.net/browse/AP20-813)): a document-ingest endpoint caps a single request at 25 MB and requires a three-step signed upload above that. The connector has to pick a path per file, and downloading a 27 MB PDF just to measure it is not an option inside a 128 MB lambda.

## Behaviour

Accepts everything `createReadStream` accepts, so anything streamable is also sizeable:

| Location | Result |
|---|---|
| `s3://bucket/key` | `headObject` → `ContentLength` |
| `https://s3.amazonaws.com/bucket/key` | same |
| `{ $src: 's3://…' }` | unwrapped first, same as `createReadStream` |
| `file:///path` | `fs.statSync().size` |

It answers for the stream `createReadStream` would produce, so a range location returns its `length` and makes no request at all. Ranges on `file://` are rejected, because `createReadStream` does not honour them there either — and `RX_FILE` being greedy, the suffix would otherwise land inside the path and surface as ENOENT for a file that never existed.

A missing `ContentLength` rejects: returning `0` would read as "small" to a caller routing by size, the exact mistake this helper exists to prevent. A genuinely empty object still returns `0`.

## Also fixes: `createReadStream` read one byte too many on every range

An HTTP byte range is inclusive at both ends, so the last byte of a `length`-byte slice starting at `offset` sits at `offset + length - 1`. The code asked for `offset + length`.

Confirmed against a live workflow payload (`?offset=2706&length=332`):

- 332 bytes is exactly one JSON record, ending `…"COMPANY"}]`
- the 333rd byte is the `\n` separating the next record

That is why it has gone unnoticed: the writers of these ranges separate records with a newline, and `JSON.parse` ignores trailing whitespace. Any range read whose next byte is not whitespace has been getting corrupt data.

Verified after the fix, against the same live object: `loadJson` returns the single expected record, `getObjectSize` on the range returns 332 with no request, and on the whole object 26,531.

This is what makes the range branch of `getObjectSize` honest, so both land together — shipping the size helper with a refusal whose stated reason is a bug we could fix in the same diff would leave an unexplained restriction behind.

The function is `async`, so every failure — bad argument, unsupported location, missing local file, S3 error — reaches the caller as a rejection rather than as a throw while the argument is being evaluated. `TypeError` for a missing or non-string url, `Error` for an unsupported format.

`aws-sdk` moves from `devDependencies` to `peerDependencies`. The entry point requires it at load time, so the contract needs to be declared; a plain `dependency` would add the whole SDK v2 to every consumer bundle when the Lambda runtime already provides it.

## Tests

Both new suites stub `aws.S3` and run fully offline, following the pattern of the existing `createWriteStream.options` unit test.

`tests/unit/getObjectSize.test.js` covers both accepted URI forms, the `{ $src }` envelope, `file://` sizing against a real temp file, a `headObject` failure, a range url answered without a request, a range rejected on `file://`, `ContentLength` absent vs `0`, and that every failure arrives through the rejection channel.

`tests/unit/createReadStream.range.test.js` pins the range arithmetic — `?offset=2706&length=332` must ask for `bytes=2706-3037`, `length=1` for `bytes=0-0`, and no range means no `Range` header.

`npm run test:unit` — **19 passing** (4 existing + 15 new).

## Notes for reviewers

- Behaviour change to be aware of: ranged reads now return `length` bytes instead of `length + 1`. For the JSON payloads this package is used for the parsed result is identical, since the extra byte was the newline separator — verified on production data. `length=0` would now produce an invalid range; nothing produces it today, and a loud S3 error beats silently returning one byte.
- Version bumped to **0.7.0** in a separate commit, matching how 0.6.0 was released.
- **Consumer, stated accurately:** cn-core#80 as pushed (`745b047`) still *adds* its own `src/utils/getS3ObjectSize.ts`, still declares `aws-sdk` directly, still pins `v0.4.0`, and still binds `apin.getS3ObjectSize`. The rewrite that deletes that copy, drops the dependency, renames the binding to `apin.getObjectSize` and bumps to `v0.7.0` is prepared but not pushed yet — it lands after this PR merges and is tagged, so the two PRs stop contradicting each other. The name `getObjectSize` wins on both sides, since it sizes `file://` too.


[AP20-813]: https://projectcx.atlassian.net/browse/AP20-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ